### PR TITLE
Increased a Provider Test's Receive Timeout

### DIFF
--- a/test/provider_test.exs
+++ b/test/provider_test.exs
@@ -11,7 +11,7 @@ defmodule Ptolemy.ProviderTest do
 
   test "register_ttl will regester the ttl properly" do
     Ptolemy.ProviderTest.TestProvider.register_ttl(self(), "test_query", 1, :milliseconds)
-    assert_receive({:expired, {Ptolemy.ProviderTest.TestProvider, "test_query"}}, 2)
+    assert_receive({:expired, {Ptolemy.ProviderTest.TestProvider, "test_query"}}, 10)
   end
 
   describe "ttl conversions:" do


### PR DESCRIPTION
Gave a more generous for the timeout test to schedule the sending of an expired message. Pipeline runners are slow :(