### PR TITLE
Feature/gcp engine

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -8,6 +8,7 @@ config :ptolemy,
       vault_url: "https://test-vault.com",
       engines: [
         gcp_engine: %{
+          engine_type: :GCP,
           engine_path: "gcp/"
         }
       ],
@@ -35,8 +36,12 @@ config :ptolemy,
           engine_path: "secret/",
           secrets: %{
             test_secret: "/test_secret"
+          }
+        },
+        gcp_engine1: %{
+          engine_type: :GCP,
+          engine_path: "gcp/"
         }
-      }
       ],
       auth: %{
         method: :Approle,

--- a/lib/engines/gcp/gcp.ex
+++ b/lib/engines/gcp/gcp.ex
@@ -1,0 +1,277 @@
+defmodule Ptolemy.Engines.GCP do
+  @moduledoc """
+  `Ptolemy.Engines.GCP` provides interaction with Vault's Google Cloud Secrets Engine.
+  """
+  alias Ptolemy.Server
+  alias Ptolemy.Engines.GCP.Engine
+
+  @typedoc """
+  Types of Google Cloud Secrets allowed by Vault
+  """
+  @type gcp_secret_type() :: :access_token | :service_account_key
+
+  @typedoc """
+    A GCP roleset map
+
+    ## Fields
+    * `:secret_type` - type of secret generated for this role set. i.e. "access_token", "service_account_key"
+    * `:project` - name of the GCP project to which this roleset's service account will belong
+    * `:bindings` - bindings configuration string (read more here: https://www.vaultproject.io/docs/secrets/gcp/index.html#roleset-bindings)
+    * `:token_scopes` - *Applies only if secret type is `access_token`* list of OAuth scopes belonging to secrets generated under this role set
+  """
+  @type roleset :: %{
+          required(:secret_type) => String.t(),
+          required(:project) => String.t(),
+          required(:bindings) => String.t(),
+          optional(:token_scopes) => list(String.t())
+        }
+
+  @doc """
+  Creates a roleset account in the given engine and returns `:ok` if everything goes well.
+  Throws an error message otherwise.
+  """
+  @spec create!(pid(), atom(), String.t(), roleset) :: :ok
+  def create!(pid, engine_name, roleset_name, roleset_payload) do
+    create(pid, engine_name, roleset_name, roleset_payload)
+    |> case do
+      {:ok, _body} -> :ok
+      {:error, err} -> raise err
+    end
+  end
+
+  @doc """
+  Generates an `access token`/`service account key` from the given roleset,
+  returning a map containing secret data and throwing an error of an issue occurs.
+  """
+  @spec read!(pid(), atom(), gcp_secret_type, String.t()) :: map()
+  def read!(pid, engine_name, secret_type, roleset_name) do
+    read(pid, engine_name, secret_type, roleset_name)
+    |> case do
+      {:ok, body} -> body
+      {:error, err} -> raise err
+    end
+  end
+
+  @doc """
+  Updates a roleset account given a new payload and returns `:ok` if everything goes well.
+  Throws an error message otherwise.
+  """
+  @spec update!(pid(), atom(), String.t(), roleset) :: :ok
+  def update!(pid, engine_name, roleset_name, roleset_payload) do
+    update(pid, engine_name, roleset_name, roleset_payload)
+    |> case do
+      {:ok, _} -> :ok
+      {:error, err} -> raise err
+    end
+  end
+
+  @doc """
+  Rotates a roleset account and returns `:ok` if everyting goes well.
+  Throws an error message otherwise.
+
+  See the documentation for `delete/4` for more information on the exact behaviour
+  of rotating rolesets.
+  """
+  @spec delete!(pid(), atom(), gcp_secret_type, String.t()) :: :ok
+  def delete!(pid, engine_name, secret_type, roleset_name) do
+    delete(pid, engine_name, secret_type, roleset_name)
+    |> case do
+      {:ok, _} -> :ok
+      {:error, err} -> raise err
+    end
+  end
+
+  @doc """
+  Retreives the current configuration for a given roleset. The response can be used for
+  changing the bindings or scopes to then update the roleset. Throws an error if anything
+  goes wrong.
+  """
+  @spec read_roleset!(pid(), atom(), String.t()) :: roleset
+  def read_roleset!(pid, engine_name, roleset_name) do
+    create_client(pid, engine_name)
+    |> Engine.read_roleset(roleset_name)
+    |> case do
+      {:ok, body} -> body
+      {:error, err} -> raise err
+    end
+  end
+
+  @doc """
+  Creates a roleset account in the given engine from which `access token`s and
+  `service account key`s can be generated.
+
+  ## Example
+  ```elixir
+  iex(1)> Ptolemy.Engines.GCP.create(server, :gcp_engine, "roleset_name", %{
+    bindings: "resource \"//cloudresourcemanager.googleapis.com/projects/project-name\" {roles = [\"roles/viewer\"]}",
+    project: "project-name",
+    secret_type: "service_account_key"
+  })
+  {:ok, "Roleset implemented"}
+  ```
+  """
+  @spec create(pid(), atom(), String.t(), roleset) :: {:ok | :error, String.t()}
+  def create(pid, engine_name, roleset_name, roleset_payload) do
+    create_client(pid, engine_name)
+    |> Engine.create_roleset(roleset_name, roleset_payload)
+  end
+
+  @doc """
+  Generates an `access token`/`service account key` from the given roleset
+
+  ## Example
+  ```elixir
+  iex(2)> Ptolemy.Engines.GCP.read(server, :gcp_engine, :service_account_key, "roleset_name")
+  {:ok, %{
+    "key_algorithm" => "KEY_ALG_RSA_2048"
+    "key_type" => "TYPE_GOOGLE_CREDENTIALS_FILE",
+    "private_key_data" => "shhh....."
+  }}
+
+  iex(3)> Ptolemy.Engines.GCP.read(server, :gcp_engine, :access_token, "access_roleset")
+  {:ok, %{
+    "expires_at_seconds" => 1553274174,
+    "token" => "shhh.....",
+    "token_ttl" => 3599
+  }}
+  ```
+  """
+  @spec read(pid(), atom(), gcp_secret_type, String.t()) :: {:ok, map()} | {:error, String.t()}
+  def read(pid, engine_name, secret_type, roleset_name) do
+    client = create_client(pid, engine_name)
+
+    case secret_type do
+      :access_token -> client |> Engine.gen_token(roleset_name)
+      :service_account_key -> client |> Engine.gen_key(roleset_name)
+      _ -> {:error, "unrecognized gcp secret type"}
+    end
+  end
+
+  @doc """
+  Updates a roleset by simply calling `create` with the new payload. This changes the
+  account email. Note that once a roleset is created, only the attributes `bindings` and `token_scopes`
+  can be changed.
+
+  If you are unsure of a roleset's configuration, it is recommended that you use the
+  function `read_roleset!/3`, update the resulting map, and then call `update` with the
+  new map to ensure that you are modifying only the editable attributes.
+
+  ## Example
+  ```elixir
+  iex(4)> Ptolemy.Engines.GCP.update(server, :gcp_engine, "roleset_name", %{
+    bindings: "resource \"//cloudresourcemanager.googleapis.com/projects/project-name\" {roles = [\"roles/editor\"]}",
+    project: "project-name",
+    secret_type: "service_account_key"
+  })
+  {:ok, "Roleset implemented"}
+  ```
+  """
+  @spec update(pid(), atom(), String.t(), roleset) :: {:ok | :error, String.t()}
+  def update(pid, engine_name, roleset_name, roleset_payload) do
+    create(pid, engine_name, roleset_name, roleset_payload)
+  end
+
+  @doc """
+  The Vault Google Secret Engine API offers multiple endpoints for rotating roleset accounts to
+  invalidate previously generated secrets. There are two methods:
+
+  ## Rotate Roleset Account Key
+    * This method is only for `access_token` secrets and is triggered by calling this function with `:access_token`
+    * This method will change the KeyID that the roleset account uses to generate secrets
+    * Based on testing, this method does not invalidate previously generated tokens but we're supporting it anyway
+
+  ## Rotate Roleset Account
+    * This method is works for both `gcp_secret_type`s and is triggered by calling this function with `:service_account_key`
+    * This method will replace the KeyID AND the email that the roleset account uses to generate secrets
+    * Based on testing, this method immediately invalidates previously generated secrets
+
+  ## Example
+  ```elixir
+  iex(5)> Ptolemy.Engines.GCP.delete(server, :gcp_engine, :service_account_key, "new_roleset")
+  {:ok, "Rotated"}
+  ```
+  """
+  @spec delete(pid(), atom(), gcp_secret_type, String.t()) :: {:ok | :error, String.t()}
+  def delete(pid, engine_name, secret_type, roleset_name) do
+    client = create_client(pid, engine_name)
+
+    case secret_type do
+      :access_token -> client |> Engine.rotate_roleset_key(roleset_name)
+      :service_account_key -> client |> Engine.rotate_roleset(roleset_name)
+      _ -> {:error, "Unrecognized GCP secret type"}
+    end
+  end
+
+  @doc """
+  Generates type `roleset` from inputs
+  """
+  @spec generate_roleset(gcp_secret_type, String.t(), String.t(), list(String.t())) :: roleset
+  def generate_roleset(secret_type, project, bindings, scopes \\ []) do
+    case secret_type do
+      :access_token ->
+        %{
+          secret_type: "access_token",
+          project: project,
+          bindings: bindings,
+          token_scopes: scopes
+        }
+
+      :service_account_key ->
+        %{
+          secret_type: "service_account_key",
+          project: project,
+          bindings: bindings
+        }
+
+      _ ->
+        {:error, "Unrecognized GCP secret type"}
+    end
+  end
+
+  @doc """
+  Creates a Tesla Client whose base URL refers to the given GCP engine.
+  The GCP Engine requires this client to make API calls to the correct engine
+  """
+  @spec create_client(pid(), atom()) :: Tesla.Client.t()
+  def create_client(pid, engine_name) do
+    creds = Server.fetch_credentials(pid)
+
+    {:ok, url} = Server.get_data(pid, :vault_url)
+    {:ok, engines} = Server.get_data(pid, :engines)
+
+    engine_path =
+      engines
+      |> Keyword.fetch!(engine_name)
+      |> Map.fetch!(:engine_path)
+
+    adapter =
+      {Tesla.Adapter.Hackney, [ssl_options: [{:versions, [:"tlsv1.2"]}], recv_timeout: 10_000]}
+
+    middleware = client_middleware(Mix.env(), url, engine_path, creds)
+
+    if Mix.env() == :test do
+      Tesla.client(middleware)
+    else
+      Tesla.client(middleware, adapter)
+    end
+  end
+
+  @doc false
+  defp client_middleware(:test, base_url, engine_path, creds) do
+    [
+      {Tesla.Middleware.BaseUrl, "#{base_url}/v1/#{engine_path}"},
+      {Tesla.Middleware.Headers, creds},
+      {Tesla.Middleware.JSON, []}
+    ]
+  end
+
+  @doc false
+  defp client_middleware(_env, base_url, engine_path, creds) do
+    [
+      {Tesla.Middleware.BaseUrl, "#{base_url}/v1/#{engine_path}"},
+      {Tesla.Middleware.Headers, creds},
+      {Tesla.Middleware.Timeout, timeout: 10_000},
+      {Tesla.Middleware.JSON, []}
+    ]
+  end
+end

--- a/lib/engines/gcp/gcp_engine.ex
+++ b/lib/engines/gcp/gcp_engine.ex
@@ -1,0 +1,112 @@
+defmodule Ptolemy.Engines.GCP.Engine do
+  @moduledoc """
+  `Ptolemy.Engines.GCP.Engine` provides low level API interaction with the Vault GCP Secrets Engine
+
+  More information on the API this implements can be found at https://www.vaultproject.io/api/secret/gcp/index.html
+  """
+
+  alias Ptolemy.Engines.GCP
+
+  @doc """
+  Submits a POST request to the client to create a roleset
+  """
+  @spec create_roleset(Tesla.Client.t(), String.t(), GCP.roleset()) :: {:ok | :error, String.t()}
+  def create_roleset(client, name, payload) do
+    with {:ok, resp} <- Tesla.post(client, "roleset/#{name}", payload) do
+      case {resp.status, resp.body} do
+        {status, _body} when status in 200..299 ->
+          {:ok, "Roleset implemented"}
+
+        {status, body} ->
+          message = Map.fetch!(body, "errors")
+          {:error, "Roleset creation failed, Status: #{status} with error: #{message}"}
+      end
+    end
+  end
+
+  @doc """
+  Submits a GET request to the client to retrieve the configuration of a given roleset.
+  """
+  @spec read_roleset(Tesla.Client.t(), String.t()) :: {:ok, map()} | {:error, String.t()}
+  def read_roleset(client, roleset_name) do
+    with {:ok, resp} <- Tesla.get(client, "roleset/#{roleset_name}") do
+      case {resp.status, resp.body} do
+        {status, body} when status in 200..299 ->
+          {:ok, body["data"]}
+
+        {status, body} ->
+          message = Map.fetch!(body, "errors")
+          {:error, "Reading roleset failed, Status: #{status} with error: #{message}"}
+      end
+    end
+  end
+
+  @doc """
+  Submits a POST request to the client to rotate a roleset account's email and Key ID
+  """
+  @spec rotate_roleset(Tesla.Client.t(), String.t()) :: {:ok | :error, String.t()}
+  def rotate_roleset(client, roleset_name) do
+    with {:ok, resp} <- Tesla.post(client, "roleset/#{roleset_name}/rotate", %{}) do
+      case {resp.status, resp.body} do
+        {status, _body} when status in 200..299 ->
+          {:ok, "Rotated"}
+
+        {status, body} ->
+          message = Map.fetch!(body, "errors")
+          {:error, "Rotate roleset failed, Status: #{status} with error: #{message}"}
+      end
+    end
+  end
+
+  @doc """
+  Submits a POST request to the client to rotate a roleset account's Key ID. Only works on
+  `access_token` type rolesets.
+  """
+  @spec rotate_roleset_key(Tesla.Client.t(), String.t()) :: {:ok | :error, String.t()}
+  def rotate_roleset_key(client, roleset_name) do
+    with {:ok, resp} <- Tesla.post(client, "roleset/#{roleset_name}/rotate-key", %{}) do
+      case {resp.status, resp.body} do
+        {status, _body} when status in 200..299 ->
+          {:ok, "Rotated"}
+
+        {status, body} ->
+          message = Map.fetch!(body, "errors")
+          {:error, "Rotate-key roleset failed, Status: #{status} with error: #{message}"}
+      end
+    end
+  end
+
+  @doc """
+  Submits a GET request to the client to retrieve a temporary Oauth2 token from an `access_token` roleset.
+  """
+  @spec gen_token(Tesla.Client.t(), String.t()) :: {:ok, map()} | {:error, String.t()}
+  def gen_token(client, roleset_name) do
+    with {:ok, resp} <- Tesla.get(client, "token/#{roleset_name}") do
+      case {resp.status, resp.body} do
+        {status, body} when status in 200..299 ->
+          {:ok, body["data"]}
+
+        {status, body} ->
+          message = Map.fetch!(body, "errors")
+          {:error, "Generating Oauth2 token failed, Status: #{status} with error: #{message}"}
+      end
+    end
+  end
+
+  @doc """
+  Submits a GET request to the client to retrieve a service account key from a `service_account_key` roleset.
+  """
+  @spec gen_key(Tesla.Client.t(), String.t()) :: {:ok, map()} | {:error, String.t()}
+  def gen_key(client, roleset_name) do
+    with {:ok, resp} <- Tesla.get(client, "key/#{roleset_name}") do
+      case {resp.status, resp.body} do
+        {status, body} when status in 200..299 ->
+          {:ok, body["data"]}
+
+        {status, body} ->
+          message = Map.fetch!(body, "errors")
+          {:error, "Generating svc acc key failed, Status: #{status} with error: #{message}"}
+      end
+    end
+  end
+end

--- a/lib/engines/kv/kv.ex
+++ b/lib/engines/kv/kv.ex
@@ -1,6 +1,6 @@
 defmodule Ptolemy.Engines.KV do
   @moduledoc """
-  `Ptolemy.Engines.KV.Vault` provides interaction with Vaults KV2 Engine
+  `Ptolemy.Engines.KV` provides interaction with Vaults KV2 Engine
   """
 
   alias Ptolemy.Engines.KV.Engine
@@ -12,7 +12,7 @@ defmodule Ptolemy.Engines.KV do
   ## Example
   ```elixir
   iex(2)> Ptolemy.Engines.KV.read(:production, :engine1, :ptolemy, "test")
-  {:ok, "test"} 
+  {:ok, "test"}
   ```
   """
   @spec read(pid(), atom(), atom(), String.t(), integer) :: {:ok | :error, String.t()}
@@ -37,14 +37,13 @@ defmodule Ptolemy.Engines.KV do
   ## Example
   ```elixir
   iex(2)> Ptolemy.Engines.KV.path_read(:production, "secret/data/ptolemy", "test")
-  {:ok, "test"} 
+  {:ok, "test"}
   ```
   """
   @spec path_read(pid(), String.t(), String.t(), integer) :: {:ok | :error, String.t()}
   def path_read(pid, secret_path, key, version \\ 0) do
     with {:ok, map} <- path_fetch(pid, secret_path, true, version),
-      {:ok, values} <- Map.fetch(map, key)
-    do
+         {:ok, values} <- Map.fetch(map, key) do
       {:ok, values}
     else
       :error -> {:error, "Could not find: #{key} in the remote vault server"}
@@ -53,15 +52,15 @@ defmodule Ptolemy.Engines.KV do
 
   @doc """
   Fetches all of a secret's keys and value via the `:kv_engine` configuration.
-  
+
   See `fetch/2` for the description of the silent and version options.
   ## Example
   ```elixir
   iex(2)> Ptolemy.Engines.KV.fetch(:production, :engine1, :ptolemy)
-  {:ok, %{ 
+  {:ok, %{
       "test" => i am some value"
       ...
-    } 
+    }
   }
   ```
   """
@@ -89,10 +88,10 @@ defmodule Ptolemy.Engines.KV do
   ## Example
   ```elixir
   iex(2)> Ptolemy.Engines.KV.path_fetch(:production, "secret/data/ptolemy")
-  {:ok, %{ 
+  {:ok, %{
       "Foo" => test"
       ...
-    } 
+    }
   }
   ```
   """
@@ -102,18 +101,22 @@ defmodule Ptolemy.Engines.KV do
     opts = [version: version]
 
     {:ok, resp} = Engine.read_secret(client, secret, opts)
+
     case resp do
-      %{} ->     
+      %{} ->
         case silent do
-          true -> 
-            {:ok ,resp
-            |> Map.get("data")
-            |> Map.get("data")
-            }
+          true ->
+            {:ok,
+             resp
+             |> Map.get("data")
+             |> Map.get("data")}
+
           false ->
             {:ok, resp}
         end
-      _ -> {:error, "Fetch from kv engine failed"}
+
+      _ ->
+        {:error, "Fetch from kv engine failed"}
     end
   end
 
@@ -131,15 +134,14 @@ defmodule Ptolemy.Engines.KV do
     path_update(pid, path, payload, cas)
   end
 
-  
   @doc """
   Same as function without an exclamation mark, but it raise an exception when failed, refer to above
   """
-  @spec update!(pid(), atom(), atom(), map(), integer) :: :ok 
+  @spec update!(pid(), atom(), atom(), map(), integer) :: :ok
   def update!(pid, engine_name, secret, payload, cas \\ nil) do
     case update(pid, engine_name, secret, payload, cas) do
       {:error, msg} -> raise RuntimeError, message: msg
-      resp -> :ok
+      _resp -> :ok
     end
   end
 
@@ -151,7 +153,7 @@ defmodule Ptolemy.Engines.KV do
   {:ok, "KV secret updated"}
   ```
   """
-  @spec path_update(pid(), String.t(),  integer) :: {:ok | :error, String.t()}
+  @spec path_update(pid(), String.t(), integer) :: {:ok | :error, String.t()}
   def path_update(pid, secret, payload, cas \\ nil) when is_bitstring(secret) do
     case path_create(pid, secret, payload, cas) do
       {:ok, _} -> {:ok, "KV secret updated"}
@@ -159,31 +161,29 @@ defmodule Ptolemy.Engines.KV do
     end
   end
 
-
   @doc """
   Creates a secret according to the path specified in the ":kv_engine" specification
-  
+
   ## Example
   ```
   iex(2)> Ptolemy.Engines.KV.create(:production, :engine1, :ptolemy, %{test: "i was created from config"})
   {:ok, "KV secret created"}
   ```
   """
-  @spec create(pid(), atom(), atom(),  map(), integer) :: :ok
+  @spec create(pid(), atom(), atom(), map(), integer) :: :ok
   def create(pid, engine_name, secret, payload, cas \\ nil) do
     path = get_kv_path!(pid, engine_name, secret, "data")
     path_create(pid, path, payload, cas)
   end
 
-
   @doc """
   Same as function without an exclamation mark, but it raise an exception when failed, refer to above
   """
-  @spec create!(pid(), atom(), atom(),  map(), integer) :: :ok
+  @spec create!(pid(), atom(), atom(), map(), integer) :: :ok
   def create!(pid, engine_name, secret, payload, cas \\ nil) do
     case create(pid, engine_name, secret, payload, cas) do
       {:error, msg} -> raise RuntimeError, message: msg
-      resp -> :ok
+      _resp -> :ok
     end
   end
 
@@ -194,7 +194,7 @@ defmodule Ptolemy.Engines.KV do
   iex(2)> Ptolemy.Engines.KV.path_create(:production, "secret/data/new", %{test: "i am created from path"})
   {:ok, "KV secret created"}
   """
-  @spec path_create(pid(), String.t(),  map(), integer) :: {:ok | :error, String.t()}
+  @spec path_create(pid(), String.t(), map(), integer) :: {:ok | :error, String.t()}
   def path_create(pid, secret, payload, cas \\ nil) when is_bitstring(secret) do
     client = create_client(pid)
     Engine.create_secret(client, secret, payload, cas)
@@ -210,24 +210,24 @@ defmodule Ptolemy.Engines.KV do
   @spec delete(pid(), atom(), atom(), integer, boolean) :: {:ok | :error, String.t()}
   def delete(pid, engine_name, secret, vers, destroy \\ false) do
     case destroy do
-      true -> 
+      true ->
         path = get_kv_path!(pid, engine_name, secret, "destroy")
         path_destroy(pid, path, vers)
-      false -> 
+
+      false ->
         path = get_kv_path!(pid, engine_name, secret, "delete")
         path_delete(pid, path, vers)
     end
   end
 
-
-    @doc """
+  @doc """
   Same as function without an exclamation mark, but it raise an exception when failed, refer to above
   """
-  @spec delete!(pid(), atom(), atom(), integer, boolean) :: :ok 
+  @spec delete!(pid(), atom(), atom(), integer, boolean) :: :ok
   def delete!(pid, engine_name, secret, vers, destroy \\ false) do
     case delete(pid, engine_name, secret, vers, destroy) do
       {:error, msg} -> raise RuntimeError, message: msg
-      resp -> :ok
+      _resp -> :ok
     end
   end
 
@@ -260,11 +260,11 @@ defmodule Ptolemy.Engines.KV do
   @doc """
   Same as function without an exclamation mark, but it raise an exception when failed, refer to above
   """
-  @spec destroy!(pid(), atom(), atom(), integer) :: :ok 
+  @spec destroy!(pid(), atom(), atom(), integer) :: :ok
   def destroy!(pid, engine_name, secret, vers) do
     case destroy(pid, engine_name, secret, vers) do
       {:error, msg} -> raise RuntimeError, message: msg
-      resp -> :ok
+      _resp -> :ok
     end
   end
 
@@ -281,11 +281,11 @@ defmodule Ptolemy.Engines.KV do
     Engine.destroy(client, secret, vers)
   end
 
-  #Tesla client function
+  # Tesla client function
   defp create_client(pid) do
     creds = Server.fetch_credentials(pid)
     {:ok, url} = Server.get_data(pid, :vault_url)
-    IO.inspect creds
+
     Tesla.client([
       {Tesla.Middleware.BaseUrl, "#{url}/v1"},
       {Tesla.Middleware.Headers, creds},
@@ -293,34 +293,31 @@ defmodule Ptolemy.Engines.KV do
     ])
   end
 
-  #Helper functions to make paths
+  # Helper functions to make paths
   defp get_kv_path!(pid, engine_name, secret, operation) when is_atom(secret) do
     with {:ok, conf} <- Server.get_data(pid, :engines),
-      {:ok, kv_conf} <- Keyword.fetch(conf, engine_name),
-      %{engine_path: path, secrets: secrets} <- kv_conf
-    do
+         {:ok, kv_conf} <- Keyword.fetch(conf, engine_name),
+         %{engine_path: path, secrets: secrets} <- kv_conf do
       {:ok, secret_path} = Map.fetch(secrets, secret)
       make_kv_path!(path, secret_path, operation)
     else
-      {:error, "Not found!"} -> throw "#{pid} does not have a kv_engine config"
-      :error -> throw "Could not find engine_name in specified config"
+      {:error, "Not found!"} -> throw("#{pid} does not have a kv_engine config")
+      :error -> throw("Could not find engine_name in specified config")
     end
   end
 
   defp get_kv_path!(pid, engine_name, secret, operation) when is_bitstring(secret) do
     with {:ok, conf} <- Server.get_data(pid, :engines),
-      {:ok, kv_conf} <- Keyword.fetch(conf, engine_name),
-      %{engine_path: path, secrets: secrets} <- kv_conf
-    do
+         {:ok, kv_conf} <- Keyword.fetch(conf, engine_name),
+         %{engine_path: path, secrets: _secrets} <- kv_conf do
       make_kv_path!(path, secret, operation)
     else
-      {:error, "Not found!"} -> throw "#{pid} does not have a kv_engine config"
-      :error -> throw "Could not find engine_name in specified config"
+      {:error, "Not found!"} -> throw("#{pid} does not have a kv_engine config")
+      :error -> throw("Could not find engine_name in specified config")
     end
   end
 
   defp make_kv_path!(engine_path, secret_path, operation) do
     "/#{engine_path}#{operation}#{secret_path}"
   end
-
 end

--- a/lib/ptolemy.ex
+++ b/lib/ptolemy.ex
@@ -3,40 +3,40 @@ defmodule Ptolemy do
   `Ptolemy` provides client side functions calls to fetch, sets and update secrets within a remote vault server.
 
   ## Configuration
-    In order to properly use ptolemy, you must properly set a ptolemy configuration block. The configuration block must start with a key of type 
+    In order to properly use ptolemy, you must properly set a ptolemy configuration block. The configuration block must start with a key of type
     atom. It is recommended that the key be named after the remote vault server it is describing.
 
     The available configuration option are as follows:
     - `:vault_url` ::string **(Required)** - The url of the remote vault server.
 
     - `:auth_mode` ::string **(Required)** - The authentication method that ptolemy will try to do. As of `0.1.0`, `"GCP"` and `"approle"` are the only supported authentication methods.
-    
+
     - `:engines` ::list - The engines list configuration, all your engines configuration should be store in here.
       - A key with an engine name will correspond to a map containing:
         - `:engine_type` ::atom - the engine type value should always be the same as the module that implements the engine, e.g. KV, GCP.
         - `:engine_path` ::string - The engine's path, always need to start with the name and end with a `/`.
-        - `:secrets` ::map - The path of each secrets you wish to use. Note each secret will be a map in Vault 
-    
+        - `:secrets` ::map - The path of each secrets you wish to use. Note each secret will be a map in Vault
+
     - `:credentials` ::map **(Required)** - The sets of credentials that will be used to authenticate to vault
       - If you are using the Approle auth method:
         - `:role_id` ::string - The role ID to use to authenticate.
         - `:secred_id` ::string - The secret ID to use to authenticate.
-      
+
       - If you are using the GCP auth method:
         - `:svc_acc` ::Based64 encoded string - The Google service account used to authenticate through IAP and/or vault.
-      
+
        - In either case where you are using IAP you must provide `:target_audience` ::string - This is the client_id of the OAuth client
       protecting the resource. Can be found in Security -> Identity-Aware-Proxy -> Select the IAP resource -> Edit OAuth client.
-    
+
     - `:opts` ::List - Optional list.
       - `:iap_on` ::boolean - Sets whether the remote vautl server has IAP protection or not. If you are using GCP auth method you must provide
         a service account credential with both `Service Account Token Creator` and `Secured IAP User`. If you are using the Approle auth method
         you must provide `:svc_acc` and a `:target_audience` (client_id of the IAP protected resource) within the `:credential` block.
-      
+
       - `:exp` ::integer - The expiry of each access token (IAP - if enabled - and the vault token). The value has a default of 900 seconds(15 min), keep in mind
       the maximum time allowed for any google tokens is 3600 (1 hour), for vault that is entirely depended on what the administrator sets (default is 15min).
 
-  ## Configuration Examples: 
+  ## Configuration Examples:
     - For an approle configuration
     ```elixir
     config :ptolemy, :vaults,
@@ -66,7 +66,7 @@ defmodule Ptolemy do
   require Logger
 
   alias Ptolemy.Server
-  alias Ptolemy.Engines.KV
+
   @doc """
   Entrypoint of ptolemy, this will start the process and store all necessary state for a connection to a remote vault server.
   Please make sure the configuration for `server` exists in your confi file
@@ -74,7 +74,7 @@ defmodule Ptolemy do
   ## Example
   ```elixir
   iex(2)> {:ok, server} = Ptolemy.start(:production, :server1)
-  {:ok, #PID<0.228.0>} 
+  {:ok, #PID<0.228.0>}
   ```
   """
   @spec start(atom, atom) :: {:ok, pid} | {:error, String.t()}
@@ -85,8 +85,8 @@ defmodule Ptolemy do
   @doc """
   create secrets in Vault, but it is not responsible for adding these secrets into the application configuration.
   opts requirements, ARGUMENTS MUST BE AN ORDERED LIST as follow
-  
-  :kv_engine
+
+  KV Engine
     1. secret (Required)
     2. payload (Required)
     3. cas (Optional, default: nil)
@@ -94,45 +94,74 @@ defmodule Ptolemy do
   ## Example
   ```elixir
   iex(1)> Ptolemy.create(server, :kv_engine1, [:ptolemy, %{test: "foo"}])
-  :ok 
+  :ok
   ```
-  
-  :gcp_engine
+
+  GCP Engine
+    1. roleset name (Required)
+    2. roleset configuration payload(Required)
+
+  ## Example
+  ```elixir
+  iex(1)> Ptolemy.create(server, :gcp_engine1, ["roleset_name", %{
+    bindings: "bindings",
+    project: "project-name",
+    secret_type: "service_account_key"
+  }])
+  {:ok, "Roleset implemented"}
+  ```
   """
   @spec create(pid, atom, [any]) :: :ok | {:ok, any()} | {:error, any()}
   def create(pid, engine_name, opts \\ []) do
-    Kernel.apply(Module.concat(Ptolemy.Engines, get_engine_type!(pid, engine_name)), :create, [pid, engine_name | opts] )
+    Kernel.apply(Module.concat(Ptolemy.Engines, get_engine_type!(pid, engine_name)), :create, [
+      pid,
+      engine_name | opts
+    ])
   end
 
   @doc """
   read all secrets from vault path
-  
+
   opts requirements, ARGUMENTS MUST BE AN ORDERED LIST as follow
 
-  :kv_engine
+  KV Engine
     1. secret (Required)
     2. silent (Optional, default: false), use silent option if you want the data ONLY
     3. version (Optional, default: 0)
-  
+
   ## Example
   ```elixir
   iex(2)> Ptolemy.read(server, :kv_engine1, [:ptolemy, true])
   {:ok, %{"test" => "foo"}}
   ```
+
+  GCP Engine
+    1. gcp secret type (Required)
+    2. roleset name (Required)
+
+  ## Example
+  ```elixir
+  iex(2)> Ptolemy.read(server, :gcp_engine1, [:service_account_key, "roleset_name"])
+  {:ok, %{
+    token: "shhh...",
+    expires_at_seconds: 1537400046,
+    token_ttl: 3599
+    }}
+  ```
   """
   @spec read(pid, atom, [any]) :: :ok | {:ok, any()} | {:error, any()}
   def read(pid, engine_name, opts \\ [], access_keys \\ []) do
-    Module.concat(Ptolemy.Engines, get_engine_type!(pid, engine_name)) 
-    |> apply(:fetch, [pid, engine_name | opts])
+    Module.concat(Ptolemy.Engines, get_engine_type!(pid, engine_name))
+    |> apply(:read, [pid, engine_name | opts])
     |> custom_get_in(access_keys)
   end
 
   @doc """
   Updates a secret
-  
+
   opts requirements, ARGUMENTS MUST BE AN ORDERED LIST as follow
 
-  :kv_engine
+  KV Engine
     1. secret (Required)
     2. payload (Required)
     3. cas (Optional, default: nil)
@@ -141,23 +170,41 @@ defmodule Ptolemy do
   ```elixir
   iex(3)> Ptolemy.update(server, :kv_engine1, [:ptolemy, %{test: "bar"}])
   :ok
+
+  GCP Engine
+    1. roleset name (Required)
+    2. roleset configuration payload (Required)
+
+  See Ptolemy.Engines.GCP documentation for restrictions on updating rolesets
+
+  ## Example
+  ```elixir
+  iex(3)> Ptolemy.update(server, :gcp_engine1, ["roleset_name", %{
+    bindings: "bindings",
+    project: "project-name",
+    secret_type: "service_account_key"
+  }])
+  {:ok, "Roleset implemented"}
   ```
   """
   @spec update(pid, atom, [any]) :: :ok | {:ok, any()} | {:error, any()}
   def update(pid, engine_name, opts \\ []) do
-    Kernel.apply(Module.concat(Ptolemy.Engines, get_engine_type!(pid, engine_name)), :update, [pid, engine_name | opts])
+    Kernel.apply(Module.concat(Ptolemy.Engines, get_engine_type!(pid, engine_name)), :update, [
+      pid,
+      engine_name | opts
+    ])
   end
 
   @doc """
   Delete a secret
-  
+
   opts requirements, ARGUMENTS MUST BE AN ORDERED LIST as follow
 
-  :kv_engine
+  KV Engine
     1. secret (Required)
     2. vers (Required)
     3. destroy (Optional, default: false)
-    
+
     destroy will leave no trace of the secret
 
   ## Example
@@ -165,10 +212,25 @@ defmodule Ptolemy do
   iex(4)> Ptolemy.delete(server, :kv_engine1, [:ptolemy, [1]])
   :ok
   ```
+
+  GCP Engine
+    1. gcp secret type (Required)
+    2. roleset name (Required)
+
+  See Ptolemy.Engines.GCP documentation for more information regarding deleting GCP secrets
+
+  ## Example
+  ```elixir
+  iex(4)> Ptolemy.delete(server, :gcp_engine1, [:access_token, "roleset_name"])
+  {:ok, "Rotated"}
+  ```
   """
   @spec delete(pid, atom, [any]) :: :ok | {:ok, any()} | {:error, any()}
   def delete(pid, engine_name, opts \\ []) do
-    Kernel.apply(Module.concat(Ptolemy.Engines, get_engine_type!(pid, engine_name)), :delete, [pid, engine_name | opts])
+    Kernel.apply(Module.concat(Ptolemy.Engines, get_engine_type!(pid, engine_name)), :delete, [
+      pid,
+      engine_name | opts
+    ])
   end
 
   @doc """
@@ -176,9 +238,8 @@ defmodule Ptolemy do
   """
   defp get_engine_type!(pid, engine_name) do
     with {:ok, conf} <- Server.get_data(pid, :engines),
-      {:ok, engine_conf} <- Keyword.fetch(conf, engine_name),
-      {:ok, engine_type} <- Map.fetch(engine_conf, :engine_type)
-    do
+         {:ok, engine_conf} <- Keyword.fetch(conf, engine_name),
+         {:ok, engine_type} <- Map.fetch(engine_conf, :engine_type) do
       engine_type
     else
       {:error, "Not found!"} -> raise "#{pid} does not have a engine config for #{engine_name}"
@@ -186,7 +247,7 @@ defmodule Ptolemy do
     end
   end
 
-  defp custom_get_in(data, [] = key_list) do
+  defp custom_get_in(data, [] = _key_list) do
     data
   end
 

--- a/test/engines/gcp_test.exs
+++ b/test/engines/gcp_test.exs
@@ -1,0 +1,245 @@
+defmodule Ptolemy.Engines.GCPTest do
+  use ExUnit.Case
+  import Tesla.Mock
+
+  alias Ptolemy.Engines.GCP
+
+  @vurl "https://test-vault.com"
+  @gcp_engine_path "gcp/"
+
+  @roleset_name "roleset_name"
+  @roleset_name_broken "roleset_doesnt_exist"
+  @roleset_config "{\"bindings\":\"resource \\\"//cloudresourcemanager.googleapis.com/projects/project-name\\\" {roles = [\\\"roles/viewer\\\"]}\",\"project\":\"project-name\",\"secret_type\":\"access_token\",\"token_scopes\":[\"https://www.googleapis.com/auth/cloud-platform\",\"https://www.googleapis.com/auth/bigquery\"]}"
+  @roleset_config_broken "{\"project\":\"project-name\",\"secret_type\":\"access_token\",\"token_scopes\":[\"https://www.googleapis.com/auth/cloud-platform\"]}"
+
+  @read_roleset_response %{
+    "data" => %{
+      "secret_type" => "access_token",
+      "service_account_email" => "vault-myroleset-XXXXXXXXXX@myproject.gserviceaccounts.com",
+      "service_account_project" => "service-account-project",
+      "bindings" => "bindings",
+      "token_scopes" => [
+        "https://www.googleapis.com/auth/cloud-platform"
+      ]
+    }
+  }
+
+  setup_all do
+    mock_global(fn
+      %{method: :post, url: "#{@vurl}/v1/auth/approle/login"} ->
+        json(
+          %{
+            "auth" => %{
+              "renewable" => true,
+              "lease_duration" => 2_764_800,
+              "metadata" => %{},
+              "policies" => [
+                "default",
+                "dev-policy",
+                "test-policy"
+              ],
+              "accessor" => "5d7fb475-07cb-4060-c2de-1ca3fcbf0c56",
+              "client_token" => "98a4c7ab-FAKE-361b-ba0b-e307aacfd587"
+            }
+          },
+          status: 200
+        )
+    end)
+
+    :ok
+  end
+
+  setup do
+    mock(fn
+      # create (and update)
+      %{
+        method: :post,
+        url: "#{@vurl}/v1/#{@gcp_engine_path}roleset/#{@roleset_name}",
+        body: @roleset_config
+      } ->
+        %Tesla.Env{status: 204, body: ""}
+
+      %{
+        method: :post,
+        url: "#{@vurl}/v1/#{@gcp_engine_path}roleset/#{@roleset_name}",
+        body: @roleset_config_broken
+      } ->
+        %Tesla.Env{status: 400, body: %{"errors" => ["error_msg"]}}
+
+      # delete (aka rotate) secrets
+      %{
+        method: :post,
+        url: "#{@vurl}/v1/#{@gcp_engine_path}roleset/#{@roleset_name}/rotate"
+      } ->
+        %Tesla.Env{status: 204, body: ""}
+
+      %{
+        method: :post,
+        url: "#{@vurl}/v1/#{@gcp_engine_path}roleset/#{@roleset_name_broken}/rotate"
+      } ->
+        %Tesla.Env{status: 400, body: %{"errors" => ["error_msg"]}}
+
+      # delete (aka rotate) access tokens only
+      %{
+        method: :post,
+        url: "#{@vurl}/v1/#{@gcp_engine_path}roleset/#{@roleset_name}/rotate-key"
+      } ->
+        %Tesla.Env{status: 204, body: ""}
+
+      %{
+        method: :post,
+        url: "#{@vurl}/v1/#{@gcp_engine_path}roleset/#{@roleset_name_broken}/rotate-key"
+      } ->
+        %Tesla.Env{status: 400, body: %{"errors" => ["error_msg"]}}
+
+      # read roleset config
+      %{
+        method: :get,
+        url: "#{@vurl}/v1/#{@gcp_engine_path}roleset/#{@roleset_name}"
+      } ->
+        %Tesla.Env{status: 200, body: @read_roleset_response}
+
+      %{
+        method: :get,
+        url: "#{@vurl}/v1/#{@gcp_engine_path}roleset/#{@roleset_name_broken}"
+      } ->
+        %Tesla.Env{status: 400, body: %{"errors" => ["error_msg"]}}
+
+      # read secret from roleset
+      %{
+        method: :get,
+        url: "#{@vurl}/v1/#{@gcp_engine_path}token/#{@roleset_name}"
+      } ->
+        %Tesla.Env{
+          status: 200,
+          body: %{
+            "data" => %{token: "shhh...", expires_at_seconds: 1_537_400_046, token_ttl: 3599}
+          }
+        }
+
+      %{
+        method: :get,
+        url: "#{@vurl}/v1/#{@gcp_engine_path}token/#{@roleset_name_broken}"
+      } ->
+        %Tesla.Env{status: 400, body: %{"errors" => ["error_msg"]}}
+
+      %{
+        method: :get,
+        url: "#{@vurl}/v1/#{@gcp_engine_path}key/#{@roleset_name}"
+      } ->
+        %Tesla.Env{
+          status: 200,
+          body: %{
+            "data" => %{
+              private_key_data: "shhh....",
+              key_algorithm: "TYPE_GOOGLE_CREDENTIALS_FILE",
+              key_type: "KEY_ALG_RSA_2048"
+            }
+          }
+        }
+
+      %{
+        method: :get,
+        url: "#{@vurl}/v1/#{@gcp_engine_path}key/#{@roleset_name_broken}"
+      } ->
+        %Tesla.Env{status: 400, body: %{"errors" => ["error_msg"]}}
+    end)
+
+    :ok
+  end
+
+  test "generate roleset" do
+    assert GCP.generate_roleset(:access_token, "project", "bindings", ["scope1", "scope2"]) === %{
+             secret_type: "access_token",
+             project: "project",
+             bindings: "bindings",
+             token_scopes: ["scope1", "scope2"]
+           }
+
+    assert GCP.generate_roleset(:service_account_key, "project", "bindings") === %{
+             secret_type: "service_account_key",
+             project: "project",
+             bindings: "bindings"
+           }
+  end
+
+  test "Ptolemy.create roleset" do
+    {:ok, server} = Ptolemy.start(:production, :server2)
+
+    assert {:ok, "Roleset implemented"} ===
+             Ptolemy.create(server, :gcp_engine1, [@roleset_name, @roleset_config])
+
+    assert {:error, "Roleset creation failed, Status: 400 with error: error_msg"} ===
+             Ptolemy.create(server, :gcp_engine1, [@roleset_name, @roleset_config_broken])
+  end
+
+  test "Ptolemy.read secret" do
+    {:ok, server} = Ptolemy.start(:production, :server2)
+
+    assert {:ok, %{token: "shhh...", expires_at_seconds: 1_537_400_046, token_ttl: 3599}} ===
+             Ptolemy.read(server, :gcp_engine1, [:access_token, @roleset_name])
+
+    assert {:error, "Generating Oauth2 token failed, Status: 400 with error: error_msg"} ===
+             Ptolemy.read(server, :gcp_engine1, [:access_token, @roleset_name_broken])
+
+    assert {:ok,
+            %{
+              private_key_data: "shhh....",
+              key_algorithm: "TYPE_GOOGLE_CREDENTIALS_FILE",
+              key_type: "KEY_ALG_RSA_2048"
+            }} === Ptolemy.read(server, :gcp_engine1, [:service_account_key, @roleset_name])
+
+    assert {:error, "Generating svc acc key failed, Status: 400 with error: error_msg"} ===
+             Ptolemy.read(server, :gcp_engine1, [:service_account_key, @roleset_name_broken])
+  end
+
+  test "Ptolemy.update roleset" do
+    {:ok, server} = Ptolemy.start(:production, :server2)
+
+    assert {:ok, "Roleset implemented"} ===
+             Ptolemy.update(server, :gcp_engine1, [@roleset_name, @roleset_config])
+
+    assert {:error, "Roleset creation failed, Status: 400 with error: error_msg"} ===
+             Ptolemy.update(server, :gcp_engine1, [@roleset_name, @roleset_config_broken])
+  end
+
+  test "Ptolemy.delete (rotate) roleset" do
+    {:ok, server} = Ptolemy.start(:production, :server2)
+
+    assert {:ok, "Rotated"} ===
+             Ptolemy.delete(server, :gcp_engine1, [:service_account_key, @roleset_name])
+
+    assert {:error, "Rotate roleset failed, Status: 400 with error: error_msg"} ===
+             Ptolemy.delete(server, :gcp_engine1, [:service_account_key, @roleset_name_broken])
+
+    assert {:ok, "Rotated"} ===
+             Ptolemy.delete(server, :gcp_engine1, [:access_token, @roleset_name])
+
+    assert {:error, "Rotate-key roleset failed, Status: 400 with error: error_msg"} ===
+             Ptolemy.delete(server, :gcp_engine1, [:access_token, @roleset_name_broken])
+  end
+
+  test "read roleset configuration" do
+    {:ok, server} = Ptolemy.start(:production, :server2)
+
+    assert @read_roleset_response["data"] ===
+             GCP.read_roleset!(server, :gcp_engine1, @roleset_name)
+
+    assert_raise(
+      RuntimeError,
+      "Reading roleset failed, Status: 400 with error: error_msg",
+      fn -> GCP.read_roleset!(server, :gcp_engine1, @roleset_name_broken) end
+    )
+  end
+
+  test "CRUD bang! functions" do
+    {:ok, server} = Ptolemy.start(:production, :server2)
+
+    assert :ok === GCP.create!(server, :gcp_engine1, @roleset_name, @roleset_config)
+    assert :ok === GCP.update!(server, :gcp_engine1, @roleset_name, @roleset_config)
+    assert :ok === GCP.delete!(server, :gcp_engine1, :access_token, @roleset_name)
+
+    assert %{token: "shhh...", expires_at_seconds: 1_537_400_046, token_ttl: 3599} ===
+             GCP.read!(server, :gcp_engine1, :access_token, @roleset_name)
+  end
+end

--- a/test/ptolemy_server_test.exs
+++ b/test/ptolemy_server_test.exs
@@ -126,29 +126,32 @@ defmodule PtolemyServerTest do
   end
 
   test "dump config server2" do
-    {:ok, server} = Server.start_link(:vault1, :server2)
+    {:ok, server} = Server.start_link(:vault1, :server1)
 
     assert Server.dump(server) ===
              {:ok,
               %{
                 vault_url: "https://test-vault.com",
                 engines: [
-                  kv_engine1: %{
-                    engine_type: :KV,
-                    engine_path: "secret/",
-                    secrets: %{
-                      test_secret: "/test_secret"
+                  gcp_engine: %{
+                    engine_type: :GCP,
+                    engine_path: "gcp/"
                   }
-                }
                 ],
                 auth: %{
-                  method: :Approle,
+                  method: :GCP,
                   credentials: %{
-                    role_id: "test",
-                    secret_id: "test"
+                    gcp_svc_acc:
+                      "{\"type\":\"service_account\",\"token_uri\":\"https://accounts.google.com/o/oauth2/token\",\"project_id\":\"some-id-of-a-fake-project\",\"private_key_id\":\"WHY-are-you-trying-to-steal-this\",\"private_key\":\"-----BEGIN RSA PRIVATE KEY-----\\nMIIBOAIBAAJAfake/pem/fake/pem/UUJjt4/G0UsrH+nDeEzNuTsJx9JVgtl4f8\\nfake/pem/tw5CbE8PDOA1vLo8cZT1R6YjQIDAQABAkBierbKXuJvjIZ5rid6ZztP\\nfake/pem/fa5QgbkBeqT4M3WxMEo79zdSneN+kY1T0iGmpyjy+ZhnkQ6exrI9q/B\\nAiEAx0MPjnWosvnPo3JLGv4Ufake/pem/w8PdPIlUqzRH/kCIQCYCV2k2S8Qh06c\\ntFlvN7HsJgQp46aM/f7FNZWobn1KNQIgT1We4vxrf17A0fWWe5e/6biQFPbap7XP\\nh8wdGg6ecJkCIA/EoOaw87WmItwTxFbJkvVn9/SUPLjQuvSfGxdt5ialAiBWKC3h\\nH2aPlTKO5Y7Fb1YTszIG7FbFGpiWDFlpeOn4VA==\\n-----END RSA PRIVATE KEY-----\",\"client_x509_cert_url\":\"https://www.googleapis.com/dont/bother/bots/becuase/this-is-a-fake-svc-acc@project-id.iam.gserviceaccount.com\",\"client_id\":\"123456789\",\"client_email\":\"this-is-a-fake-svc-acc@project-id.iam.gserviceaccount.com\",\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"auth_provider_x509_cert_url\":\"https://www.googleapis.com/oauth2/v1/certs\"}",
+                    vault_role: "write-role",
+                    exp: 900
                   },
                   auto_renew: true,
-                  opts: []
+                  opts: [
+                    iap_svc_acc: :reuse,
+                    client_id: "asasd229384sdhjff9efhbe234FAKE.apps.googleusercontent.com",
+                    exp: 900
+                  ]
                 }
               }}
   end
@@ -157,8 +160,9 @@ defmodule PtolemyServerTest do
     {:ok, server} = Server.start_link(:vault1, :server2)
     # The first time is fetched from the endpoint
     assert Server.fetch_credentials(server) === [
-      {"X-Vault-Token", "98a4c7ab-FAKE-361b-ba0b-e307aacfd587"}
-    ]
+             {"X-Vault-Token", "98a4c7ab-FAKE-361b-ba0b-e307aacfd587"}
+           ]
+
     # pulls token field without error from the server
     assert Server.fetch_credentials(server) === [
              {"X-Vault-Token", "98a4c7ab-FAKE-361b-ba0b-e307aacfd587"}


### PR DESCRIPTION
post rebase w/ verified commits

adding a GCP engine to handle interactions with Vault's Google Cloud Secrets Engine API

TODO

- [x]  Map Ptolemy's CRUD interface to GCP's interface
- [x]   Document the use of the gcp engine
- [x]   Fulfill as much of the Vault GCP engine API as needed (considering LIST requests aren't supported by Tesla)
- [x]   Write tests/mocks (blocked until completion of ptolemy.ex)
