### PR TITLE
Add HTTP Opts to Engine Clients

### DIFF
--- a/lib/engines/kv/kv.ex
+++ b/lib/engines/kv/kv.ex
@@ -263,11 +263,13 @@ defmodule Ptolemy.Engines.KV do
   # Tesla client function
   defp create_client(server_name) do
     creds = Server.fetch_credentials(server_name)
+    http_opts = Server.get_data(server_name, :http_opts)
     {:ok, url} = Server.get_data(server_name, :vault_url)
 
     Tesla.client([
       {Tesla.Middleware.BaseUrl, "#{url}/v1"},
       {Tesla.Middleware.Headers, creds},
+      {Tesla.Middleware.Opts, http_opts},
       {Tesla.Middleware.JSON, []}
     ])
   end

--- a/lib/engines/kv/kv.ex
+++ b/lib/engines/kv/kv.ex
@@ -263,7 +263,7 @@ defmodule Ptolemy.Engines.KV do
   # Tesla client function
   defp create_client(server_name) do
     creds = Server.fetch_credentials(server_name)
-    http_opts = Server.get_data(server_name, :http_opts)
+    {:ok, http_opts} = Server.get_data(server_name, :http_opts)
     {:ok, url} = Server.get_data(server_name, :vault_url)
 
     Tesla.client([

--- a/lib/engines/pki/pki.ex
+++ b/lib/engines/pki/pki.ex
@@ -285,11 +285,13 @@ defmodule Ptolemy.Engines.PKI do
   # Tesla client function
   defp create_client(server_name) do
     creds = Server.fetch_credentials(server_name)
+    {:ok, http_opts} = Server.get_data(server_name, :http_opts)
     {:ok, url} = Server.get_data(server_name, :vault_url)
 
     Tesla.client([
       {Tesla.Middleware.BaseUrl, "#{url}/v1"},
       {Tesla.Middleware.Headers, creds},
+      {Tesla.Middleware.Opts, http_opts},
       {Tesla.Middleware.JSON, []}
     ])
   end

--- a/test/ptolemy_server_test.exs
+++ b/test/ptolemy_server_test.exs
@@ -194,7 +194,7 @@ defmodule PtolemyServerTest do
               Map.put(state, :tokens, [
                 {"X-Vault-Token", "98a4c7ab-FAKE-361b-ba0b-e307aacfd587"},
                 {"Authorization", "Bearer 98a4c7ab98a4c7ab98a4c7ab"}
-              ])}
+                ]) |> Map.put(:http_opts, [])}
 
     alt_state = Map.put(state, :auth, non_renewed_approle_auth)
 
@@ -212,7 +212,7 @@ defmodule PtolemyServerTest do
               Map.put(alt_state, :tokens, [
                 {"X-Vault-Token", "98a4c7ab-FAKE-361b-ba0b-e307aacfd587"},
                 {"Authorization", "Bearer 98a4c7ab98a4c7ab98a4c7ab"}
-              ])}
+              ]) |> Map.put(:http_opts, [])}
   end
 
   test "approle handle_call :auth" do
@@ -234,7 +234,7 @@ defmodule PtolemyServerTest do
                  renewable: true,
                  token: {"X-Vault-Token", "98a4c7ab-FAKE-361b-ba0b-e307aacfd587"}
                }},
-              Map.put(state, :tokens, [{"X-Vault-Token", "98a4c7ab-FAKE-361b-ba0b-e307aacfd587"}])}
+              Map.put(state, :tokens, [{"X-Vault-Token", "98a4c7ab-FAKE-361b-ba0b-e307aacfd587"}]) |> Map.put(:http_opts, [])}
 
     alt_state = Map.put(state, :auth, non_renewed_approle_auth)
 
@@ -248,7 +248,7 @@ defmodule PtolemyServerTest do
                }},
               Map.put(alt_state, :tokens, [
                 {"X-Vault-Token", "98a4c7ab-FAKE-361b-ba0b-e307aacfd587"}
-              ])}
+              ]) |> Map.put(:http_opts, [])}
   end
 
   test "purge" do
@@ -326,6 +326,7 @@ defmodule PtolemyServerTest do
     state_new_token =
       state
       |> Map.put(:tokens, [{"X-Vault-Token", "98a4c7ab-FAKE-361b-ba0b-e307aacfd587"}])
+      |> Map.put(:http_opts, [])
 
     assert Server.handle_info({:auto_renew_vault, mode, url, creds, opts}, state_exp_token) ===
              {:noreply, state_new_token}
@@ -364,6 +365,7 @@ defmodule PtolemyServerTest do
         {"X-Vault-Token", "98a4c7ab-FAKE-361b-ba0b-e307aacfd587"},
         {"Authorization", "Bearer 98a4c7ab98a4c7ab98a4c7ab"}
       ])
+      |> Map.put(:http_opts, [])
 
     assert Server.handle_info(
              {:auto_renew_vault, mode, url, parsed_creds, opts},


### PR DESCRIPTION
# Description

In order to specify the cacert for ssl_options in the case of kubernetes auth, the opts for the HTTP engine clients needs to be set. A new key http_opts is maintained in the ptolemy_server state.