### PR TITLE
Add refresh time to allow for periodically re-pulling confiiguration

### DIFF
--- a/test/loader_test.exs
+++ b/test/loader_test.exs
@@ -46,6 +46,24 @@ defmodule Ptolemy.LoaderTest do
       assert Application.get_env(test_name, :testval) == "THIS_WORKED"
     end
 
+    test "loader refreshes application value correctly", %{test: test_name} do
+      Application.put_env(test_name, :testval, "THIS_WORKED")
+
+      {:ok, _loader} =
+        Loader.start_link(
+          refresh_time: 1000,
+          env: [
+            {{test_name, :testval},
+             {LoaderTest.EchoProvider, Application.get_env(test_name, :testval)}}
+          ]
+        )
+
+      assert Application.get_env(test_name, :testval) == "THIS_WORKED"
+      Application.put_env(test_name, :testval, "THIS_CHANGED")
+      :timer.sleep(1000)
+      assert Application.get_env(test_name, :testval) == "THIS_CHANGED"
+    end
+
     test "recieving an expired message will re-pull value", %{test: test_name} do
       {:ok, loader} =
         Loader.start_link(


### PR DESCRIPTION
# Description

A new keyword called refresh time is added to loader to allow for reloading of configuration given a specific refresh time

Here is it in action
<img width="755" alt="Screen Shot 2020-05-25 at 3 09 34 PM" src="https://user-images.githubusercontent.com/20006218/82839023-05f12d00-9e9c-11ea-8b94-4adf38028b84.png">

This is in Iris, I set a refresh time of 30 seconds and I changed the environment on vault and the reflected change showed up in iris config.
