### PR TITLE
Update Tesla to use TLS v1.2 for issues with Certificate Authority

### DIFF
--- a/lib/auth/auth.ex
+++ b/lib/auth/auth.ex
@@ -223,12 +223,15 @@ defmodule Ptolemy.Auth do
   """
   @spec vault_auth_client(String.t(), list(), list()) :: %Tesla.Client{}
   def vault_auth_client(url, headers, opts) do
-    Tesla.client([
-      {Tesla.Middleware.BaseUrl, "#{url}/v1"},
-      {Tesla.Middleware.Headers, headers},
-      {Tesla.Middleware.Opts, opts},
-      {Tesla.Middleware.JSON, []}
-    ])
+    Tesla.client(
+      [
+        {Tesla.Middleware.BaseUrl, "#{url}/v1"},
+        {Tesla.Middleware.Headers, headers},
+        {Tesla.Middleware.Opts, opts},
+        {Tesla.Middleware.JSON, []}
+      ],
+      {Tesla.Adapter.Hackney, [ssl_options: [{:versions, [:"tlsv1.2"]}], recv_timeout: 10_000]}
+    )
   end
 
   # parses auth body to return relevant information

--- a/lib/engines/kv/kv.ex
+++ b/lib/engines/kv/kv.ex
@@ -266,12 +266,15 @@ defmodule Ptolemy.Engines.KV do
     {:ok, http_opts} = Server.get_data(server_name, :http_opts)
     {:ok, url} = Server.get_data(server_name, :vault_url)
 
-    Tesla.client([
-      {Tesla.Middleware.BaseUrl, "#{url}/v1"},
-      {Tesla.Middleware.Headers, creds},
-      {Tesla.Middleware.Opts, http_opts},
-      {Tesla.Middleware.JSON, []}
-    ])
+    Tesla.client(
+      [
+        {Tesla.Middleware.BaseUrl, "#{url}/v1"},
+        {Tesla.Middleware.Headers, creds},
+        {Tesla.Middleware.Opts, http_opts},
+        {Tesla.Middleware.JSON, []}
+      ],
+      {Tesla.Adapter.Hackney, [ssl_options: [{:versions, [:"tlsv1.2"]}], recv_timeout: 10_000]}
+    )
   end
 
   # Helper functions to make paths

--- a/lib/engines/pki/pki.ex
+++ b/lib/engines/pki/pki.ex
@@ -288,12 +288,15 @@ defmodule Ptolemy.Engines.PKI do
     {:ok, http_opts} = Server.get_data(server_name, :http_opts)
     {:ok, url} = Server.get_data(server_name, :vault_url)
 
-    Tesla.client([
-      {Tesla.Middleware.BaseUrl, "#{url}/v1"},
-      {Tesla.Middleware.Headers, creds},
-      {Tesla.Middleware.Opts, http_opts},
-      {Tesla.Middleware.JSON, []}
-    ])
+    Tesla.client(
+      [
+        {Tesla.Middleware.BaseUrl, "#{url}/v1"},
+        {Tesla.Middleware.Headers, creds},
+        {Tesla.Middleware.Opts, http_opts},
+        {Tesla.Middleware.JSON, []}
+      ],
+      {Tesla.Adapter.Hackney, [ssl_options: [{:versions, [:"tlsv1.2"]}], recv_timeout: 10_000]}
+    )
   end
 
   # Helper functions to make paths

--- a/lib/ptolemy_server.ex
+++ b/lib/ptolemy_server.ex
@@ -159,7 +159,7 @@ defmodule Ptolemy.Server do
 
       %{secret_id: _id, role_id: _rid} = parsed ->
         {:ok, parsed}
-      
+
       %{kube_client_token: _, vault_role: _, cluster_name: _} = parsed ->
         {:ok, parsed}
 
@@ -212,7 +212,10 @@ defmodule Ptolemy.Server do
             Process.send_after(self(), {:purge, :iap}, opts[:exp] * 1000)
           end
 
-          {:reply, {:ok, res}, state |> Map.put(:tokens, access_token) |> Map.put(:http_opts, opts |> Keyword.get(:http_opts, []))}
+          {:reply, {:ok, res},
+           state
+           |> Map.put(:tokens, access_token)
+           |> Map.put(:http_opts, opts |> Keyword.get(:http_opts, []))}
 
         %{token: token, renewable: renewable, lease_duration: ttl} = res ->
           access_token = [token]
@@ -227,7 +230,10 @@ defmodule Ptolemy.Server do
             Process.send_after(self(), {:purge, :all}, ttl * 1000)
           end
 
-          {:reply, {:ok, res}, state |> Map.put(:tokens, access_token) |> Map.put(:http_opts, opts |> Keyword.get(:http_opts, []))}
+          {:reply, {:ok, res},
+           state
+           |> Map.put(:tokens, access_token)
+           |> Map.put(:http_opts, opts |> Keyword.get(:http_opts, []))}
 
         {:error, msg} ->
           {:reply, {:error, msg}, state}
@@ -349,7 +355,10 @@ defmodule Ptolemy.Server do
           Process.send_after(self(), {:purge, :vault}, ttl * 1000)
         end
 
-        {:noreply, state |> Map.put(:tokens, [token]) |>  Map.put(:http_opts, opts |> Keyword.get(:http_opts, []))}
+        {:noreply,
+         state
+         |> Map.put(:tokens, [token])
+         |> Map.put(:http_opts, opts |> Keyword.get(:http_opts, []))}
 
       2 ->
         [{"X-Vault-Token", _bearer}, bearer] = toks
@@ -369,7 +378,10 @@ defmodule Ptolemy.Server do
           Process.send_after(self(), {:purge, :vault}, ttl * 1000)
         end
 
-        {:noreply, state |> Map.put(:tokens, [token, bearer]) |> Map.put(:http_opts, opts |> Keyword.get(:http_opts, []))}
+        {:noreply,
+         state
+         |> Map.put(:tokens, [token, bearer])
+         |> Map.put(:http_opts, opts |> Keyword.get(:http_opts, []))}
     end
   end
 


### PR DESCRIPTION
Kept getting: {:error, {:tls_alert, {:unknown_ca, 'TLS client: In state wait_cert_cr at ssl_handshake.erl:1887 generated CLIENT ALERT: Fatal - Unknown CA\n'}}}}